### PR TITLE
Remove schema.org data from quickview HTML

### DIFF
--- a/app/views/workarea/storefront/products/quickview.html.haml
+++ b/app/views/workarea/storefront/products/quickview.html.haml
@@ -1,5 +1,3 @@
 - cache "#{@product.cache_key}/quickview", expires_in: 1.hour do
-  = render_schema_org(product_schema(@product, related_products: @product.recommendations))
-
   .product-details{ class: "product-details--#{@product.template}", data: { analytics: product_quickview_analytics_data(@product).to_json } }
     = render "workarea/storefront/products/templates/#{@product.template}", product: @product


### PR DESCRIPTION
This is causing jQuery to open extra dialogs. Removing it seems like an acceptable solution because 1) search engines and other crawlers will be following detail page links whether or not they're running JS and 2) because of the jQuery problems this isn't currently being output anyways.